### PR TITLE
feat: allow IO to be passed to upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ Example Usage:
     # upload new file
     bucket.upload("/home/jovyan/test.txt", "test/foobar.txt")
 
+    # Or upload from from in memory:
+    from io import StringIO
+    fh = StringIO()
+    fh.write("hello world")
+    fh.seek(0)
+    bucket.upload(fh, "test/foobar2.txt")
+
     # it seems newly uplaoded file will **NOT** be available immediately. Sleep for x seconds?
     from time import sleep
     sleep(1)

--- a/ebrains_drive/exceptions.py
+++ b/ebrains_drive/exceptions.py
@@ -36,3 +36,6 @@ class Unauthorized(Exception):
 class InvalidParameter(Exception): pass
 
 class TokenExpired(Exception): pass
+
+class UpstreamAPIException(Exception):
+    """This exception is raised if the upstream API returns something unexpected"""

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1,7 +1,10 @@
 import pytest
+from unittest.mock import patch, mock_open
 from unittest.mock import MagicMock
 from ebrains_drive.bucket import Bucket
 from ebrains_drive.exceptions import ClientHttpError, Unauthorized
+from io import StringIO, IOBase
+from itertools import product
 
 class MockClient:
     def get(self, *args, **kwargs):
@@ -9,11 +12,20 @@ class MockClient:
     def put(self, *args, **kwargs):
         raise NotImplementedError
 
+@pytest.fixture
+def mock_client():
+    client = MockClient()
+    client.get = MagicMock()
+    client.put = MagicMock()
+    return client
+
 class MockHttpResp:
     def __init__(self, resp):
         self.resp = resp
     def json(self):
         return self.resp
+    def raise_for_status(self):
+        ...
 
 bucket_json={
     'name': 'foo',
@@ -71,3 +83,46 @@ def test_ls_when_repeats():
         raise Exception("did not raise")
     except Exception as e:
         assert isinstance(e, RuntimeError), f"Expect raise RuntimeError: {e}"
+
+
+
+@pytest.fixture
+def mocked_request():
+    try:
+        with patch('requests.request') as patched_obj:
+            yield patched_obj
+    finally:
+        ...
+
+@pytest.fixture
+def mock_open_fixture():
+    try:
+        with patch('builtins.open', new_callable=mock_open, read_data="foo-bar") as patched_obj:
+            yield patched_obj
+    finally:
+        ...
+    
+
+
+
+@pytest.mark.parametrize('filelike,kwargs', product(
+    ["filelike", StringIO()],
+    [{"foo": "bar"}, {}]
+))
+def test_upload(filelike, kwargs, mocked_request, mock_open_fixture, mock_client: MockClient):
+    bucket = Bucket.from_json(mock_client, bucket_json)
+    mocked_request.return_value = MockHttpResp({})
+    mock_client.put.return_value = MockHttpResp({
+        'url': 'http://foo-bar.co/'
+    })
+
+    bucket.upload(filelike, 'filename', **kwargs)
+    if isinstance(filelike, str):
+        mock_open_fixture.assert_called()
+        data = mock_open_fixture.return_value
+    elif isinstance(filelike, IOBase):
+        mock_open_fixture.assert_not_called()
+        data = filelike
+    else:
+        raise RuntimeError(f" should be either str or IOBase")
+    mocked_request.assert_called_with("PUT", "http://foo-bar.co/", data=data, **kwargs )


### PR DESCRIPTION
This PR addsd the ability for user to upload file directly from in memory IO. 

e.g. 

```python
from ebrains_drive import BucketApiClient
from io import StringIO

client = BucketApiClient(token="ey...")
bucket = client.buckets.get_bucket("existing_collab_name")

fh = StringIO()
fh.write("hello world")
fh.seek(0)
bucket.upload(fh, "test/foobar2.txt")
```