### PR TITLE
feat: access public bucket with no access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ Example Usage:
     client.delete_bucket("new_bucket_name")
 ```
 
+Read access of public buckets can be done without supplying a token:
+
+```python
+
+    from ebrains_drive import BucketApiClient
+    
+    # anonymous account only has read access to public buckets
+    anon_client = BucketApiClient()
+    public_bucket = anon_client.buckets.get_bucket("reference-atlas-data")
+    
+    # list all files under static/
+    files = public_bucket.ls(prefix="static")
+    print([f.name for f in files])
+
+```
+
 ### Access datasets (e.g. HDG datasets)
 
 ```python

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Read access of public buckets can be done without supplying a token:
 
     from ebrains_drive import BucketApiClient
     
-    # anonymous account only has read access to public buckets
+    # anonymous client only has read access to public buckets
     anon_client = BucketApiClient()
     public_bucket = anon_client.buckets.get_bucket("reference-atlas-data")
     


### PR DESCRIPTION
Currently `ebrains-drive` only allows authenticated access to dataproxy.

This PR adds unauthenticated read access to public buckets.