### PR TITLE
fix: get default repo

### DIFF
--- a/ebrains_drive/repos.py
+++ b/ebrains_drive/repos.py
@@ -90,7 +90,11 @@ class Repos(object):
         Get the user's default repo (i.e. "My Library")
         """
         repos_json = self.client.get('/api2/default-repo').json()
-        return Repo.from_json(self.client, repos_json)
+        assert repos_json.get("exists"), f"Default repo does not exist."
+
+        repo_id = repos_json.get("repo_id")
+        assert repo_id, f"Expected repo_id to be populated, but wasn't"
+        return self.get_repo(repo_id)
 
     def get_repo_by_local_path(self, local_path):
         """


### PR DESCRIPTION
current implementation of getting default repo seems to be incorrect. e.g.

now

```python
from ebrains_drive import DriveApiClient

token="ey..."

client = DriveApiClient(token=token)

repo = client.repos.get_default_repo()

print(repo) # AttributeError: 'Repo' object has no attribute 'id'
```

according to [seafile api](https://lins05.gitbooks.io/seafile-docs/content/develop/web_api.html#get-default-lib) it appears the `/api2/default-repo` endpoint returns the id, and from the id, one can get the repo. 

This PR addresses this issue. 